### PR TITLE
Copy rgb color to clipboard

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -663,6 +663,9 @@ footer .button {
   background: #dddddd;
   border-radius: 50%;
 }
+.swatch:hover {
+  cursor: pointer;
+}
 
 .get-color .swatch {
   width: 4rem;

--- a/index.html
+++ b/index.html
@@ -399,7 +399,9 @@ rgbToHex(102, 51, 153); // #663399</code></pre>
       <div class="function get-color">
         <h3 class="function-title">Dominant Color</h3>
         <div class="swatches">
-          <div class="swatch" style="background-color: rgb({{color.0}}, {{color.1}}, {{color.2}})"></div>
+          <div class="swatch" style="background-color: rgb({{color.0}}, {{color.1}}, {{color.2}})" 
+            onclick='navigator.clipboard.writeText("rgb({{color.0}}, {{color.1}}, {{color.2}})")'>
+          </div>
         </div>
         <div class="function-code">
           <code>colorThief.getColor(image):{{elapsedTimeForGetColor}}ms</code>
@@ -410,7 +412,8 @@ rgbToHex(102, 51, 153); // #663399</code></pre>
         <div class="function-output">
           <div class="swatches">
             {{#palette}}
-              <div class="swatch" style="background-color: rgb({{0}}, {{1}}, {{2}})"></div>
+              <div class="swatch" style="background-color: rgb({{0}}, {{1}}, {{2}})" 
+                onclick='navigator.clipboard.writeText("rgb({{0}}, {{1}}, {{2}})")'></div>
             {{/palette}}
           </div>
         </div>


### PR DESCRIPTION
A feature was requested to copy the color of the swatches to clipboard here: https://github.com/lokesh/color-thief/issues/212

The PR copies the rgb color to clipboard when the swatch is clicked on.

Spent a little too much time on it, if anyone wishes to improve on it (e.g. copy hex color, add 'copy to clipboard' tooltip).