### PR TITLE
corrected the element to look for load on

### DIFF
--- a/index.html
+++ b/index.html
@@ -155,7 +155,7 @@ ColorThief.getPalette(img, 5)
     if (img.complete) {
       colorThief.getColor(img);
     } else {
-      image.addEventListener('load', function() {
+      img.addEventListener('load', function() {
         colorThief.getColor(img);
       });
     }


### PR DESCRIPTION
In the example of checking to see if the image had finished loading it targets `img` but the eventListener is attached to `image`.

I could be completely wrong, but I don't think I am in this instance